### PR TITLE
removal of object.map

### DIFF
--- a/lib/object.js
+++ b/lib/object.js
@@ -205,7 +205,7 @@ defineProperties(Object.prototype, {
         return false;
     },
 
-    /**
+    /*
      * Loops through the properties in an object until the callback assembling a new object
      * with its properties set to the values returned by the callback function.
      * If the callback function returns `undefined` the property will not be copied to the new object.
@@ -222,6 +222,7 @@ defineProperties(Object.prototype, {
      *                      obj {Object} the whole of the object
      * @return {Object} The new object with its properties set to the values returned by the callback function.
      */
+/* DEPRECATED --> Google maps uses its own (different) implication
     map: function (fn, context) {
         var keys = Object.keys(this),
             l = keys.length,
@@ -237,6 +238,7 @@ defineProperties(Object.prototype, {
         }
         return m;
     },
+*/
 
     /**
      * Returns the keys of the object: the enumerable properties.

--- a/tests/object.js
+++ b/tests/object.js
@@ -224,14 +224,14 @@ describe('Testing object instance methods', function () {
 		deepObj2.d.d1 = 2;
 		expect(deepObj.sameValue(deepObj2)).to.be.false;
 	});
-	it('map', function () {
-		expect(obj.map(function (value, key) {
-			return key + value;
-		})).be.eql({a:'a1',b:'b2',c:'c3'});
-		expect(obj.map(function (value, key) {
-			return (key == 'b'?undefined:key + value);
-		})).be.eql({a:'a1', c:'c3'});
-	});
+	// it('map', function () {
+	// 	expect(obj.map(function (value, key) {
+	// 		return key + value;
+	// 	})).be.eql({a:'a1',b:'b2',c:'c3'});
+	// 	expect(obj.map(function (value, key) {
+	// 		return (key == 'b'?undefined:key + value);
+	// 	})).be.eql({a:'a1', c:'c3'});
+	// });
 	it('shallowClone', function () {
 		var a = obj.shallowClone();
 		expect(a).be.eql(obj);


### PR DESCRIPTION
Google maps uses its own (different) definition
